### PR TITLE
Adding intermediate results

### DIFF
--- a/Mobilyzer/src/com/mobilyzer/MeasurementScheduler.java
+++ b/Mobilyzer/src/com/mobilyzer/MeasurementScheduler.java
@@ -185,6 +185,9 @@ public class MeasurementScheduler extends Service {
     filter.addAction(UpdateIntent.MEASUREMENT_PROGRESS_UPDATE_ACTION);
     filter.addAction(UpdateIntent.GCM_MEASUREMENT_ACTION);
     filter.addAction(UpdateIntent.PLT_MEASUREMENT_ACTION);
+    //added by Clarence
+    filter.addAction(UpdateIntent.MEASUREMENT_INTERMEDIATE_PROGRESS_UPDATE_ACTION);
+    
 
     broadcastReceiver = new BroadcastReceiver() {
 
@@ -323,7 +326,20 @@ public class MeasurementScheduler extends Service {
           } else if (intent.getStringExtra(UpdateIntent.TASK_STATUS_PAYLOAD).equals(
               Config.TASK_RESUMED)) {
             tasksStatus.put(taskid, TaskStatus.RUNNING);
-          }
+          }  //added by Clarence
+        } else if (intent.getAction().equals(UpdateIntent.MEASUREMENT_INTERMEDIATE_PROGRESS_UPDATE_ACTION)){
+        	String IM_taskKey = intent.getStringExtra(UpdateIntent.CLIENTKEY_PAYLOAD);
+            String IM_taskid = intent.getStringExtra(UpdateIntent.TASKID_PAYLOAD);
+            int IM_priority =
+                intent.getIntExtra(UpdateIntent.TASK_PRIORITY_PAYLOAD,
+                    MeasurementTask.INVALID_PRIORITY);
+            Parcelable[] IM_Results = intent.getParcelableArrayExtra(UpdateIntent.INTERMEDIATE_RESULT_PAYLOAD);
+            if (IM_Results != null && IM_Results.length!=0) {
+                sendResultToClient(IM_Results, IM_priority, IM_taskKey, IM_taskid);
+                Logger.i("Sending Intermediate results to client...");
+            	System.out.println("receive the intermediate results");
+            }
+
         } else if (intent.getAction().equals(UpdateIntent.CHECKIN_ACTION)
             || intent.getAction().equals(UpdateIntent.CHECKIN_RETRY_ACTION)) {
           Logger.d("Checkin intent received");

--- a/Mobilyzer/src/com/mobilyzer/MeasurementTask.java
+++ b/Mobilyzer/src/com/mobilyzer/MeasurementTask.java
@@ -29,6 +29,8 @@ public abstract class MeasurementTask
       Parcelable {
   protected MeasurementDesc measurementDesc;
   protected String taskId;
+  
+  private MeasurementScheduler scheduler; // added by Clarence 
 
 
   public static final int USER_PRIORITY = Integer.MIN_VALUE;
@@ -113,6 +115,15 @@ public abstract class MeasurementTask
 
   public void setKey(String key) {
     this.measurementDesc.key = key;
+  }
+  
+  // added by Clarence, pass scheduler to every specific task
+  public void setScheduler(MeasurementScheduler scheduler) {
+	    this.scheduler = scheduler;
+  }
+  
+  public MeasurementScheduler getScheduler() {
+	  return this.scheduler;
   }
 
 

--- a/Mobilyzer/src/com/mobilyzer/MeasurementTask.java
+++ b/Mobilyzer/src/com/mobilyzer/MeasurementTask.java
@@ -7,6 +7,10 @@ import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
+import android.content.Context;
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.mobilyzer.exceptions.MeasurementError;
 import com.mobilyzer.measurements.DnsLookupTask;
 import com.mobilyzer.measurements.HttpTask;
@@ -19,8 +23,7 @@ import com.mobilyzer.measurements.TracerouteTask;
 import com.mobilyzer.measurements.UDPBurstTask;
 import com.mobilyzer.measurements.VideoQoETask;
 
-import android.os.Parcel;
-import android.os.Parcelable;
+
 
 public abstract class MeasurementTask
     implements
@@ -30,7 +33,8 @@ public abstract class MeasurementTask
   protected MeasurementDesc measurementDesc;
   protected String taskId;
   
-  private MeasurementScheduler scheduler; // added by Clarence 
+  //private MeasurementScheduler scheduler; // added by Clarence 
+  private Context context = null;           //added by Clarence
 
 
   public static final int USER_PRIORITY = Integer.MIN_VALUE;
@@ -118,12 +122,12 @@ public abstract class MeasurementTask
   }
   
   // added by Clarence, pass scheduler to every specific task
-  public void setScheduler(MeasurementScheduler scheduler) {
-	    this.scheduler = scheduler;
+  public void setContext(Context context) {
+	    this.context = context;
   }
   
-  public MeasurementScheduler getScheduler() {
-	  return this.scheduler;
+  public Context getContext() {
+	  return this.context;
   }
 
 

--- a/Mobilyzer/src/com/mobilyzer/ServerMeasurementTask.java
+++ b/Mobilyzer/src/com/mobilyzer/ServerMeasurementTask.java
@@ -38,6 +38,7 @@ public class ServerMeasurementTask implements Callable<MeasurementResult[]> {
 	public ServerMeasurementTask(MeasurementTask task,
 			MeasurementScheduler scheduler, ResourceCapManager manager) {
 		realTask = task;
+		realTask.setScheduler(null);  //added by Clarence
 		this.scheduler = scheduler;
 		this.contextCollector = new ContextCollector();
 		this.rManager = manager;

--- a/Mobilyzer/src/com/mobilyzer/ServerMeasurementTask.java
+++ b/Mobilyzer/src/com/mobilyzer/ServerMeasurementTask.java
@@ -38,7 +38,7 @@ public class ServerMeasurementTask implements Callable<MeasurementResult[]> {
 	public ServerMeasurementTask(MeasurementTask task,
 			MeasurementScheduler scheduler, ResourceCapManager manager) {
 		realTask = task;
-		realTask.setScheduler(null);  //added by Clarence
+		realTask.setContext(null);  //added by Clarence
 		this.scheduler = scheduler;
 		this.contextCollector = new ContextCollector();
 		this.rManager = manager;

--- a/Mobilyzer/src/com/mobilyzer/UpdateIntent.java
+++ b/Mobilyzer/src/com/mobilyzer/UpdateIntent.java
@@ -44,6 +44,8 @@ public class UpdateIntent extends Intent {
   public static final String VIDEO_TASK_PAYLOAD_REBUFFER_TIME = "VIDEO_TASK_PAYLOAD_REBUFFER_TIME";
   public static final String VIDEO_TASK_PAYLOAD_BBA_SWITCH_TIME = "VIDEO_TASK_PAYLOAD_BBA_SWITCH_TIME";
   public static final String VIDEO_TASK_PAYLOAD_BYTE_USED = "VIDEO_TASK_PAYLOAD_BYTE_USED";
+  //added by Clarence
+  public static final String INTERMEDIATE_RESULT_PAYLOAD = "INTERMEDIATE_RESULT_PAYLOAD";
   
   
   // Different types of actions that this intent can represent:
@@ -81,6 +83,11 @@ public class UpdateIntent extends Intent {
       PACKAGE_PREFIX + ".DATA_USAGE_ACTION";
   public static final String AUTH_ACCOUNT_ACTION =
       PACKAGE_PREFIX + ".AUTH_ACCOUNT_ACTION";
+  
+  
+  // added by Clarence
+  public static final String MEASUREMENT_INTERMEDIATE_PROGRESS_UPDATE_ACTION =
+	      APP_PREFIX + ".MEASUREMENT_INTERMEDIATE_PROGRESS_UPDATE_ACTION";
 
   /**
    * Creates an intent of the specified action with an optional message

--- a/Mobilyzer/src/com/mobilyzer/UserMeasurementTask.java
+++ b/Mobilyzer/src/com/mobilyzer/UserMeasurementTask.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.concurrent.Callable;
 
+import android.content.Context;
 import android.content.Intent;
 
 import com.mobilyzer.MeasurementResult.TaskProgress;
@@ -33,6 +34,7 @@ public class UserMeasurementTask implements Callable<MeasurementResult[]> {
   public UserMeasurementTask(MeasurementTask task,
                              MeasurementScheduler scheduler) {
     realTask = task;
+    realTask.setScheduler(scheduler);  //added by Clarence
     this.scheduler = scheduler;  
     this.contextCollector= new ContextCollector();
   }
@@ -48,7 +50,10 @@ public class UserMeasurementTask implements Callable<MeasurementResult[]> {
     intent.putExtra(UpdateIntent.TASK_STATUS_PAYLOAD, Config.TASK_STARTED);
     intent.putExtra(UpdateIntent.TASKID_PAYLOAD, realTask.getTaskId());
     intent.putExtra(UpdateIntent.CLIENTKEY_PAYLOAD, realTask.getKey());
+//    Context context = scheduler.getApplicationContext();
+//    context.sendBroadcast(intent);
     scheduler.sendBroadcast(intent);
+    
   }
 
   /**
@@ -96,9 +101,12 @@ public class UserMeasurementTask implements Callable<MeasurementResult[]> {
       ArrayList<HashMap<String, String>> contextResults =
           contextCollector.stopCollector();
       for (MeasurementResult r: results){
+    	String testIntermediate1 = r.toString();
         r.addContextResults(contextResults);
         r.getDeviceProperty().dnResolvability=contextCollector.dnsConnectivity;
         r.getDeviceProperty().ipConnectivity=contextCollector.ipConnectivity;
+        String testIntermediate2 = r.toString();
+        
       } 
     } catch (MeasurementError e) {
       Logger.e("User measurement " + realTask.getDescriptor() + " has failed");

--- a/Mobilyzer/src/com/mobilyzer/UserMeasurementTask.java
+++ b/Mobilyzer/src/com/mobilyzer/UserMeasurementTask.java
@@ -34,7 +34,7 @@ public class UserMeasurementTask implements Callable<MeasurementResult[]> {
   public UserMeasurementTask(MeasurementTask task,
                              MeasurementScheduler scheduler) {
     realTask = task;
-    realTask.setScheduler(scheduler);  //added by Clarence
+    realTask.setContext(scheduler.getApplicationContext());  //added by Clarence
     this.scheduler = scheduler;  
     this.contextCollector= new ContextCollector();
   }

--- a/Mobilyzer/src/com/mobilyzer/measurements/ParallelTask.java
+++ b/Mobilyzer/src/com/mobilyzer/measurements/ParallelTask.java
@@ -165,6 +165,9 @@ public class ParallelTask extends MeasurementTask{
 
   @Override
   public MeasurementResult[] call() throws MeasurementError {
+	 for (MeasurementTask task: this.tasks){
+		 task.setScheduler(this.getScheduler());
+	 }           //added by Clarence
     long timeout=duration;
     executor=Executors.newFixedThreadPool(this.tasks.size());
 

--- a/Mobilyzer/src/com/mobilyzer/measurements/ParallelTask.java
+++ b/Mobilyzer/src/com/mobilyzer/measurements/ParallelTask.java
@@ -166,7 +166,7 @@ public class ParallelTask extends MeasurementTask{
   @Override
   public MeasurementResult[] call() throws MeasurementError {
 	 for (MeasurementTask task: this.tasks){
-		 task.setScheduler(this.getScheduler());
+		 task.setContext(this.getContext());
 	 }           //added by Clarence
     long timeout=duration;
     executor=Executors.newFixedThreadPool(this.tasks.size());

--- a/Mobilyzer/src/com/mobilyzer/measurements/PingTask.java
+++ b/Mobilyzer/src/com/mobilyzer/measurements/PingTask.java
@@ -15,6 +15,7 @@
 
 package com.mobilyzer.measurements;
 
+import android.content.Intent;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.Log;
@@ -23,7 +24,9 @@ import android.util.Log;
 import com.mobilyzer.Config;
 import com.mobilyzer.MeasurementDesc;
 import com.mobilyzer.MeasurementResult;
+import com.mobilyzer.MeasurementScheduler;
 import com.mobilyzer.MeasurementTask;
+import com.mobilyzer.UpdateIntent;
 import com.mobilyzer.MeasurementResult.TaskProgress;
 import com.mobilyzer.exceptions.MeasurementError;
 import com.mobilyzer.util.Logger;
@@ -70,6 +73,32 @@ public class PingTask extends MeasurementTask{
   private String targetIp = null;
   //Track data consumption for this task to avoid exceeding user's limit  
   private long dataConsumed;
+  
+  
+  private MeasurementScheduler scheduler = null;  // added by Clarence
+  
+  private void broadcastIntermediateMeasurement(MeasurementResult[] results, MeasurementScheduler scheduler) {
+	  this.scheduler = scheduler;
+      Intent intent = new Intent();
+      intent.setAction(UpdateIntent.MEASUREMENT_INTERMEDIATE_PROGRESS_UPDATE_ACTION);
+      //TODO fixed one value priority for all users task?
+      intent.putExtra(UpdateIntent.TASK_PRIORITY_PAYLOAD,
+        MeasurementTask.USER_PRIORITY);
+      intent.putExtra(UpdateIntent.TASKID_PAYLOAD, this.getTaskId());
+      intent.putExtra(UpdateIntent.CLIENTKEY_PAYLOAD, this.getKey());
+
+      if (results != null){
+    	  
+        //intent.putExtra(UpdateIntent.TASK_STATUS_PAYLOAD, Config.TASK_FINISHED);
+        intent.putExtra(UpdateIntent.INTERMEDIATE_RESULT_PAYLOAD, results);
+      
+      this.scheduler.sendBroadcast(intent);
+      }else{
+    	 intent.putExtra(UpdateIntent.INTERMEDIATE_RESULT_PAYLOAD, "No intermediate results are broadcasted");
+    	  
+     }
+
+    }
   
   /**
    * Encode ping specific parameters, along with common parameters inherited from MeasurmentDesc
@@ -356,6 +385,11 @@ public class PingTask extends MeasurementTask{
     PingDesc pingTask = (PingDesc) this.measurementDesc;
     String errorMsg = "";
     MeasurementResult measurementResult = null;
+    
+    MeasurementResult IM_measurementResult = null;  //added by Clarence
+    MeasurementResult[] IM_result = null;
+    IM_result = new MeasurementResult[1];
+    
     // TODO(Wenjie): Add a exhaustive list of ping locations for different
     //               Android phones
     pingTask.pingExe = Util.pingExecutableBasedOnIPType(ipByteLen);
@@ -384,11 +418,13 @@ public class PingTask extends MeasurementTask{
       ArrayList<Integer> receivedIcmpSeq = new ArrayList<Integer>();
       double packetLoss = Double.MIN_VALUE;
       int packetsSent = Config.PING_COUNT_PER_MEASUREMENT;
+      
       // Process each line of the ping output and store the rrt in array rrts.
       while ((line = br.readLine()) != null) {
         // Ping prints a number of 'param=value' pairs, among which we only need
         // the 'time=rrt_val' pair
         String[] extractedValues = Util.extractInfoFromPingOutput(line);
+       
         if (extractedValues != null) {
           int curIcmpSeq = Integer.parseInt(extractedValues[0]);
           double rrtVal = Double.parseDouble(extractedValues[1]);
@@ -409,6 +445,18 @@ public class PingTask extends MeasurementTask{
           int packetsReceived = packetLossInfo[1];
           packetLoss = 1 - ((double) packetsReceived / (double) packetsSent);
         }
+        this.scheduler = this.getScheduler();
+        if ( this.scheduler != null ){
+        	if (rrts.size() >= 2  && (rrts.size() < Config.PING_COUNT_PER_MEASUREMENT) && (extractedValues != null) ){
+        		IM_measurementResult = constructResult(rrts,packetLoss,
+            			rrts.size(),PING_METHOD_CMD);
+        		IM_result[0] = IM_measurementResult;
+        		broadcastIntermediateMeasurement(IM_result,this.scheduler);
+        		
+        		
+        	}
+        }
+        //IM_packetsSent++;
 
         Logger.i(line);
       }
@@ -452,6 +500,10 @@ public class PingTask extends MeasurementTask{
     ArrayList<Double> rrts = new ArrayList<Double>();
     String errorMsg = "";
     MeasurementResult result = null;
+    double packetLoss = Double.MIN_VALUE;           //added by Clarence
+    MeasurementResult IM_measurementResult = null;  //added by Clarence
+    MeasurementResult[] IM_result = null;
+    IM_result = new MeasurementResult[1];
 
     try {       
       int timeOut = (int) (3000 * (double) pingTask.pingTimeoutSec /
@@ -466,11 +518,28 @@ public class PingTask extends MeasurementTask{
         if (status) {
           totalPingDelay += rrtVal;
           rrts.add((double) rrtVal);
+          packetLoss = 1 -
+                ((double) rrts.size() / (i+1));
+          dataConsumed += pingTask.packetSizeByte * (i+1) * 2;
+          this.scheduler = this.getScheduler();
+          if ( this.scheduler != null){
+        	  IM_measurementResult = constructResult(rrts,packetLoss,
+            			(i+1),PING_METHOD_JAVA);
+              IM_result[0] = IM_measurementResult;
+              broadcastIntermediateMeasurement(IM_result,this.scheduler);
+        	  
+          }
+          
+          
         }
       }
       Logger.i("java ping succeeds");
-      double packetLoss = 1 -
-          ((double) rrts.size() / (double) Config.PING_COUNT_PER_MEASUREMENT);
+//      double packetLoss = 1 -
+//          ((double) rrts.size() / (double) Config.PING_COUNT_PER_MEASUREMENT);  //deleted by Clarence
+      if (packetLoss == Double.MIN_VALUE) {
+          packetLoss = 1 - 
+              ((double) rrts.size() / (double) Config.PING_COUNT_PER_MEASUREMENT);
+        }
       
       dataConsumed += pingTask.packetSizeByte * Config.PING_COUNT_PER_MEASUREMENT * 2;
       
@@ -505,6 +574,10 @@ public class PingTask extends MeasurementTask{
     PingDesc pingTask = (PingDesc) this.measurementDesc;
     String errorMsg = "";
     MeasurementResult result = null;
+    double packetLoss = Double.MIN_VALUE;           //added by Clarence
+    MeasurementResult IM_measurementResult = null;  //added by Clarence
+    MeasurementResult[] IM_result = null;
+    IM_result = new MeasurementResult[1];
 
     try {
       long totalPingDelay = 0;
@@ -525,12 +598,27 @@ public class PingTask extends MeasurementTask{
         pingEndTime = System.currentTimeMillis();
         httpClient.disconnect();
         rrts.add((double) (pingEndTime - pingStartTime));
+        packetLoss = 1 -
+                ((double) rrts.size() / (i+1));
+        dataConsumed += pingTask.packetSizeByte * (i+1) * 2;
+        this.scheduler = this.getScheduler();
+        if ( this.scheduler != null){
+        	  IM_measurementResult = constructResult(rrts,packetLoss,
+            			(i+1),PING_METHOD_HTTP);
+              IM_result[0] = IM_measurementResult;
+              broadcastIntermediateMeasurement(IM_result,this.scheduler);
+        	  
+         }
 
       }
       Logger.i("HTTP get ping succeeds");
       Logger.i("RTT is " + rrts.toString());
-      double packetLoss = 1
-          - ((double) rrts.size() / (double) Config.PING_COUNT_PER_MEASUREMENT);
+//      double packetLoss = 1
+//          - ((double) rrts.size() / (double) Config.PING_COUNT_PER_MEASUREMENT);
+      if (packetLoss == Double.MIN_VALUE) {
+          packetLoss = 1 - 
+              ((double) rrts.size() / (double) Config.PING_COUNT_PER_MEASUREMENT);
+        }
       
       dataConsumed += pingTask.packetSizeByte * Config.PING_COUNT_PER_MEASUREMENT * 2;
       

--- a/Mobilyzer/src/com/mobilyzer/measurements/PingTask.java
+++ b/Mobilyzer/src/com/mobilyzer/measurements/PingTask.java
@@ -15,6 +15,7 @@
 
 package com.mobilyzer.measurements;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -75,10 +76,10 @@ public class PingTask extends MeasurementTask{
   private long dataConsumed;
   
   
-  private MeasurementScheduler scheduler = null;  // added by Clarence
+  private Context context = null;  // added by Clarence
   
-  private void broadcastIntermediateMeasurement(MeasurementResult[] results, MeasurementScheduler scheduler) {
-	  this.scheduler = scheduler;
+  private void broadcastIntermediateMeasurement(MeasurementResult[] results, Context context) {
+	  this.context = context;
       Intent intent = new Intent();
       intent.setAction(UpdateIntent.MEASUREMENT_INTERMEDIATE_PROGRESS_UPDATE_ACTION);
       //TODO fixed one value priority for all users task?
@@ -92,7 +93,7 @@ public class PingTask extends MeasurementTask{
         //intent.putExtra(UpdateIntent.TASK_STATUS_PAYLOAD, Config.TASK_FINISHED);
         intent.putExtra(UpdateIntent.INTERMEDIATE_RESULT_PAYLOAD, results);
       
-      this.scheduler.sendBroadcast(intent);
+      this.context.sendBroadcast(intent);
       }else{
     	 intent.putExtra(UpdateIntent.INTERMEDIATE_RESULT_PAYLOAD, "No intermediate results are broadcasted");
     	  
@@ -445,13 +446,13 @@ public class PingTask extends MeasurementTask{
           int packetsReceived = packetLossInfo[1];
           packetLoss = 1 - ((double) packetsReceived / (double) packetsSent);
         }
-        this.scheduler = this.getScheduler();
-        if ( this.scheduler != null ){
+        this.context = this.getContext();
+        if ( this.context != null ){
         	if (rrts.size() >= 2  && (rrts.size() < Config.PING_COUNT_PER_MEASUREMENT) && (extractedValues != null) ){
         		IM_measurementResult = constructResult(rrts,packetLoss,
             			rrts.size(),PING_METHOD_CMD);
         		IM_result[0] = IM_measurementResult;
-        		broadcastIntermediateMeasurement(IM_result,this.scheduler);
+        		broadcastIntermediateMeasurement(IM_result,this.context);
         		
         		
         	}
@@ -521,12 +522,12 @@ public class PingTask extends MeasurementTask{
           packetLoss = 1 -
                 ((double) rrts.size() / (i+1));
           dataConsumed += pingTask.packetSizeByte * (i+1) * 2;
-          this.scheduler = this.getScheduler();
-          if ( this.scheduler != null){
+          this.context = this.getContext();
+          if ( this.context != null){
         	  IM_measurementResult = constructResult(rrts,packetLoss,
             			(i+1),PING_METHOD_JAVA);
               IM_result[0] = IM_measurementResult;
-              broadcastIntermediateMeasurement(IM_result,this.scheduler);
+              broadcastIntermediateMeasurement(IM_result,this.context);
         	  
           }
           
@@ -601,12 +602,12 @@ public class PingTask extends MeasurementTask{
         packetLoss = 1 -
                 ((double) rrts.size() / (i+1));
         dataConsumed += pingTask.packetSizeByte * (i+1) * 2;
-        this.scheduler = this.getScheduler();
-        if ( this.scheduler != null){
+        this.context = this.getContext();
+        if ( this.context != null){
         	  IM_measurementResult = constructResult(rrts,packetLoss,
             			(i+1),PING_METHOD_HTTP);
               IM_result[0] = IM_measurementResult;
-              broadcastIntermediateMeasurement(IM_result,this.scheduler);
+              broadcastIntermediateMeasurement(IM_result,this.context);
         	  
          }
 

--- a/Mobilyzer/src/com/mobilyzer/measurements/SequentialTask.java
+++ b/Mobilyzer/src/com/mobilyzer/measurements/SequentialTask.java
@@ -169,6 +169,7 @@ public class SequentialTask extends MeasurementTask{
     try {
       //      futures=executor.invokeAll(this.tasks,timeout,TimeUnit.MILLISECONDS);
       for(MeasurementTask mt: tasks){
+    	mt.setScheduler(this.getScheduler());
         if(stopFlag){
           throw new MeasurementError("Cancelled");
         }

--- a/Mobilyzer/src/com/mobilyzer/measurements/SequentialTask.java
+++ b/Mobilyzer/src/com/mobilyzer/measurements/SequentialTask.java
@@ -169,7 +169,7 @@ public class SequentialTask extends MeasurementTask{
     try {
       //      futures=executor.invokeAll(this.tasks,timeout,TimeUnit.MILLISECONDS);
       for(MeasurementTask mt: tasks){
-    	mt.setScheduler(this.getScheduler());
+    	mt.setContext(this.getContext());
         if(stopFlag){
           throw new MeasurementError("Cancelled");
         }

--- a/Mobilyzer/src/com/mobilyzer/measurements/TCPThroughputTask.java
+++ b/Mobilyzer/src/com/mobilyzer/measurements/TCPThroughputTask.java
@@ -17,7 +17,9 @@ import java.util.Random;
 
 import com.mobilyzer.MeasurementDesc;
 import com.mobilyzer.MeasurementResult;
+import com.mobilyzer.MeasurementScheduler;
 import com.mobilyzer.MeasurementTask;
+import com.mobilyzer.UpdateIntent;
 import com.mobilyzer.MeasurementResult.TaskProgress;
 import com.mobilyzer.exceptions.MeasurementError;
 import com.mobilyzer.util.Logger;
@@ -26,6 +28,7 @@ import com.mobilyzer.util.MeasurementJsonConvertor;
 import com.mobilyzer.util.PhoneUtils;
 
 import android.content.Context;
+import android.content.Intent;
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -88,6 +91,34 @@ public class TCPThroughputTask extends MeasurementTask {
   private long duration;
   private TaskProgress taskProgress;
   private volatile boolean stopFlag;
+  
+  private MeasurementScheduler scheduler = null;  // added by Clarence
+  private TaskProgress Intermediate_TaskProgress = TaskProgress.COMPLETED;  //added by Clarence
+  
+  //added by Clarence, add broadcast to send the intermediate results
+  
+  private void broadcastIntermediateMeasurement(MeasurementResult[] results, MeasurementScheduler scheduler) {
+	  this.scheduler = scheduler;
+      Intent intent = new Intent();
+      intent.setAction(UpdateIntent.MEASUREMENT_INTERMEDIATE_PROGRESS_UPDATE_ACTION);
+      //TODO fixed one value priority for all users task?
+      intent.putExtra(UpdateIntent.TASK_PRIORITY_PAYLOAD,
+        MeasurementTask.USER_PRIORITY);
+      intent.putExtra(UpdateIntent.TASKID_PAYLOAD, this.getTaskId());
+      intent.putExtra(UpdateIntent.CLIENTKEY_PAYLOAD, this.getKey());
+
+      if (results != null){
+    	  
+        //intent.putExtra(UpdateIntent.TASK_STATUS_PAYLOAD, Config.TASK_FINISHED);
+        intent.putExtra(UpdateIntent.INTERMEDIATE_RESULT_PAYLOAD, results);
+      
+      this.scheduler.sendBroadcast(intent);
+      }else{
+    	 intent.putExtra(UpdateIntent.INTERMEDIATE_RESULT_PAYLOAD, "No intermediate results are broadcasted");
+    	  
+     }
+
+  }
 
   // class constructor
   public TCPThroughputTask(MeasurementDesc desc) {
@@ -530,13 +561,17 @@ public class TCPThroughputTask extends MeasurementTask {
 
     long startTime = System.currentTimeMillis();
     long endTime = startTime;
+   
     int  data_limit_byte_up =
         (int)(((TCPThroughputDesc)measurementDesc).data_limit_mb_up
         *this.KBYTE*this.KBYTE);
     byte[] uplinkBuffer =
         new byte[((TCPThroughputDesc)measurementDesc).pkt_size_up_bytes];
     this.genRandomByteArray(uplinkBuffer);
+   
+    
     try {
+      
 
       long totalDuration = (long)(this.KSEC*
           ((TCPThroughputDesc)measurementDesc).duration_period_sec +
@@ -550,6 +585,10 @@ public class TCPThroughputTask extends MeasurementTask {
         oStream.write(uplinkBuffer, 0, uplinkBuffer.length);
         oStream.flush();
         endTime = System.currentTimeMillis();
+        
+   
+        
+        
 
         this.totalSendSize += ((TCPThroughputDesc)measurementDesc).pkt_size_up_bytes;
         if (this.DATA_LIMIT_ON &&
@@ -576,6 +615,9 @@ public class TCPThroughputTask extends MeasurementTask {
       byte [] resultMsg = new byte[this.BUFFER_SIZE];
       int resultMsgLen = iStream.read(resultMsg, 0, resultMsg.length);
       if (resultMsgLen > 0) {
+    	  
+    	MeasurementResult IntermediateResult = null;      //added by Clarence
+    	
         String resultMsgStr = new String(resultMsg).substring(0, resultMsgLen);
         // Sample result string is "1111.11#2222.22#3333.33";
         Logger.i("Uplink result from server is " + resultMsgStr);
@@ -585,6 +627,23 @@ public class TCPThroughputTask extends MeasurementTask {
           sampleResult = Double.valueOf(tps_result_str[i]);
           this.samplingResults = this.insertWithOrder(this.samplingResults,
             sampleResult);
+          
+        //added by Clarence
+          this.scheduler = this.getScheduler();  
+          if (this.scheduler != null){
+        	  PhoneUtils Intermediate_phoneUtils = PhoneUtils.getPhoneUtils();
+        	  IntermediateResult = new MeasurementResult(Intermediate_phoneUtils.getDeviceInfo().deviceId,
+        			  Intermediate_phoneUtils.getDeviceProperty(this.getKey()),TCPThroughputTask.TYPE,
+        			  System.currentTimeMillis()*1000,Intermediate_TaskProgress,this.measurementDesc);
+        	  IntermediateResult.addResult("tcp_speed_results", this.samplingResults);
+        	  IntermediateResult.addResult("data_limit_exceeded", this.DATA_LIMIT_EXCEEDED);
+        	  IntermediateResult.addResult("duration", this.taskDuration);
+        	  IntermediateResult.addResult("server_version", this.serverVersion);
+        	  MeasurementResult[] IM_mrArray = new MeasurementResult[1];
+          	  IM_mrArray[0] = IntermediateResult;
+          	  broadcastIntermediateMeasurement(IM_mrArray,this.scheduler); 
+        	  
+          }
         }
       }
       Logger.i("Total number of sampling result is " + this.samplingResults.size());
@@ -679,6 +738,9 @@ public class TCPThroughputTask extends MeasurementTask {
    * @param time period increment
    */
   private void updateSize(int delta) {
+	  
+	MeasurementResult IntermediateResult = null;      //added by Clarence
+	
     double gtime = System.currentTimeMillis() - this.taskStartTime;
     //ignore slow start
     if (gtime<((TCPThroughputDesc)measurementDesc).slow_start_period_sec*this.KSEC)
@@ -696,6 +758,24 @@ public class TCPThroughputTask extends MeasurementTask {
       this.samplingResults = this.insertWithOrder(this.samplingResults, throughput);
       this.accumulativeSize = 0;
       this.startSampleTime = System.currentTimeMillis();
+      
+      //added by Clarence
+      this.scheduler = this.getScheduler();  
+      if (this.scheduler != null){
+    	  PhoneUtils Intermediate_phoneUtils = PhoneUtils.getPhoneUtils();
+    	  IntermediateResult = new MeasurementResult(Intermediate_phoneUtils.getDeviceInfo().deviceId,
+    			  Intermediate_phoneUtils.getDeviceProperty(this.getKey()),TCPThroughputTask.TYPE,
+    			  System.currentTimeMillis()*1000,Intermediate_TaskProgress,this.measurementDesc);
+    	  IntermediateResult.addResult("tcp_speed_results", this.samplingResults);
+    	  IntermediateResult.addResult("data_limit_exceeded", this.DATA_LIMIT_EXCEEDED);
+    	  IntermediateResult.addResult("duration", time);
+    	  IntermediateResult.addResult("server_version", this.serverVersion);
+    	  MeasurementResult[] IM_mrArray = new MeasurementResult[1];
+      	  IM_mrArray[0] = IntermediateResult;
+      	  broadcastIntermediateMeasurement(IM_mrArray,this.scheduler); 
+    	  
+      }
+      
     }  
   }
 

--- a/Mobilyzer/src/com/mobilyzer/measurements/TracerouteTask.java
+++ b/Mobilyzer/src/com/mobilyzer/measurements/TracerouteTask.java
@@ -14,11 +14,6 @@
 
 package com.mobilyzer.measurements;
 
-import android.content.Intent;
-import android.os.Parcel;
-import android.os.Parcelable;
-
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,19 +36,25 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import android.content.Context;
+import android.content.Intent;
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import com.mobilyzer.Config;
 import com.mobilyzer.MeasurementDesc;
 import com.mobilyzer.MeasurementResult;
+import com.mobilyzer.MeasurementResult.TaskProgress;
 import com.mobilyzer.MeasurementScheduler;
 import com.mobilyzer.MeasurementTask;
 import com.mobilyzer.PreemptibleMeasurementTask;
 import com.mobilyzer.UpdateIntent;
-import com.mobilyzer.MeasurementResult.TaskProgress;
 import com.mobilyzer.exceptions.MeasurementError;
 import com.mobilyzer.util.Logger;
 import com.mobilyzer.util.MeasurementJsonConvertor;
 import com.mobilyzer.util.PhoneUtils;
 import com.mobilyzer.util.Util;
+
 
 
 /**
@@ -91,13 +92,13 @@ public class TracerouteTask extends MeasurementTask implements PreemptibleMeasur
 
   // Track data consumption for this task to avoid exceeding user's limit
   private long dataConsumed;
-  private MeasurementScheduler scheduler = null;  // added by Clarence
+  private Context context = null;  // added by Clarence
   private TaskProgress Intermediate_TaskProgress = TaskProgress.COMPLETED;  //added by Clarence
   
   //added by Clarence, add broadcast to send the intermediate results
   
-  private void broadcastIntermediateMeasurement(MeasurementResult[] results, MeasurementScheduler scheduler) {
-	  this.scheduler = scheduler;
+  private void broadcastIntermediateMeasurement(MeasurementResult[] results, Context context) {
+	  this.context = context;
       Intent intent = new Intent();
       intent.setAction(UpdateIntent.MEASUREMENT_INTERMEDIATE_PROGRESS_UPDATE_ACTION);
       //TODO fixed one value priority for all users task?
@@ -111,7 +112,7 @@ public class TracerouteTask extends MeasurementTask implements PreemptibleMeasur
         //intent.putExtra(UpdateIntent.TASK_STATUS_PAYLOAD, Config.TASK_FINISHED);
         intent.putExtra(UpdateIntent.INTERMEDIATE_RESULT_PAYLOAD, results);
       
-      this.scheduler.sendBroadcast(intent);
+      this.context.sendBroadcast(intent);
       }else{
     	 intent.putExtra(UpdateIntent.INTERMEDIATE_RESULT_PAYLOAD, "No intermediate results are broadcasted");
     	  
@@ -438,8 +439,8 @@ public class TracerouteTask extends MeasurementTask implements PreemptibleMeasur
           }
         }
       //added by Clarence
-        this.scheduler = this.getScheduler();
-        if (this.scheduler != null){
+        this.context = this.getContext();
+        if (this.context != null){
         
       	  PhoneUtils Intermediate_phoneUtils = PhoneUtils.getPhoneUtils();
       	  IntermediateResult = new MeasurementResult(Intermediate_phoneUtils.getDeviceInfo().deviceId,
@@ -465,7 +466,7 @@ public class TracerouteTask extends MeasurementTask implements PreemptibleMeasur
       
       	  MeasurementResult[] IM_mrArray = new MeasurementResult[1];
       	  IM_mrArray[0] = IntermediateResult;
-      	  broadcastIntermediateMeasurement(IM_mrArray,this.scheduler);  
+      	  broadcastIntermediateMeasurement(IM_mrArray,this.context);  
         }
       			
       	  

--- a/Mobilyzer/src/com/mobilyzer/measurements/UDPBurstTask.java
+++ b/Mobilyzer/src/com/mobilyzer/measurements/UDPBurstTask.java
@@ -42,7 +42,7 @@ import com.mobilyzer.util.PhoneUtils;
  * 
  * UDPBurstTask provides two types of measurements, Burst Up and Burst Down, described next.
  * 
- * 1. UDPBurst Up: the device sends sends a burst of UDPBurstCount UDP packets and waits for a
+ * 1. UDPBurst Up: the device sends a burst of UDPBurstCount UDP packets and waits for a
  * response from the server that includes the number of packets that the server received
  * 
  * 2. UDPBurst Down: the device sends a request to a remote server on a UDP port and the server


### PR DESCRIPTION
The intermediate results of traceroute, ping, and TCPThroughput are added in this new version. Also, it uses context to broadcst intermediate results rather than scheduler. I think I have uploaded the latest version, but since I am not very family with GitHub, please check if there are some problems here, thanks.